### PR TITLE
Refactor transition handling in ShellItemTrans to use Info

### DIFF
--- a/PJ.NavigationTrans.Maui/Platforms/iOS/Shell/ShellItemTrans.ios.cs
+++ b/PJ.NavigationTrans.Maui/Platforms/iOS/Shell/ShellItemTrans.ios.cs
@@ -18,9 +18,9 @@ class ShellItemTrans : IShellItemTransition
 		Assert(oldView is not null);
 		Assert(newView is not null);
 
-		var animIn = ShellTrans.GetTransitionIn(content);
+		var info = AnimationHelpers.GetInfo(content);
 
-		if (animIn == TransitionType.Default)
+		if (info.AnimationIn == TransitionType.Default || info.AnimationOut == TransitionType.Default)
 		{
 			return DefaultImpl(oldRenderer, newRenderer);
 		}
@@ -28,11 +28,8 @@ class ShellItemTrans : IShellItemTransition
 		oldView.Layer.RemoveAllAnimations();
 		oldView.Superview!.InsertSubviewAbove(newView, oldView);
 
-		var animOut = ShellTrans.GetTransitionOut(content);
-		var duration = ShellTrans.GetDuration(content) / 1_000;
-
-		oldView.SelectAndRunAnimation(animOut, duration, tcs);
-		newView.SelectAndRunAnimation(animIn, duration, tcs);
+		oldView.SelectAndRunAnimation(info.AnimationOut, info.Duration, tcs);
+		newView.SelectAndRunAnimation(info.AnimationIn, info.Duration, tcs);
 
 		return tcs.Task;
 	}


### PR DESCRIPTION
Refactor transition handling in ShellItemTrans

Updated transition logic to use AnimationHelpers for
retrieving animation types and durations. The default
implementation now checks both animation in and out types,
ensuring a more cohesive handling of animation properties.