### PR TITLE
Update Maui version and add symbol package format

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<PropertyGroup>
 		<NetVersion>net9.0</NetVersion>
-		<MauiPackageVersion>9.0.50</MauiPackageVersion>
+		<MauiVersion>9.0.70</MauiVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>preview</LangVersion>

--- a/PJ.NavigationTrans.Maui/PJ.NavigationTrans.Maui.csproj
+++ b/PJ.NavigationTrans.Maui/PJ.NavigationTrans.Maui.csproj
@@ -33,6 +33,7 @@
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">


### PR DESCRIPTION
Update Maui version and add symbol package format

Updated `MauiVersion` in `Directory.Build.props` from `9.0.50` to `9.0.70`.
Added `SymbolPackageFormat` with value `snupkg` in `PJ.NavigationTrans.Maui.csproj` to enhance debugging support.